### PR TITLE
Fix duraction assignement in case it's equal to 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "patronus"
-version = "0.0.17"
+version = "0.0.18"
 description = "Patronus Python SDK"
 authors = ["Jędrzej Rosłaniec <jedrzej@patronus.ai>"]
 license = "MIT"

--- a/src/patronus/evaluators.py
+++ b/src/patronus/evaluators.py
@@ -130,7 +130,7 @@ class Evaluator(abc.ABC):
         if isinstance(result, (int, float)):
             result = types.EvaluationResult(pass_=None, score_raw=float(result))
         if isinstance(result, api_types.EvaluationResult):
-            elapsed = result.evaluation_duration and result.evaluation_duration.seconds
+            elapsed = result.evaluation_duration and result.evaluation_duration.seconds or 0
         if isinstance(result, types.EvaluationResult):
             if not result.evaluation_duration_s:
                 result.evaluation_duration_s = elapsed


### PR DESCRIPTION
The following error is raised when returned duration is equal to 0:
```
Evaluator (exact-match-2024-05-31, patronus:exact-match) failed on sample 1 with the following error: 1 validation error for EvaluatorOutput
duration
  Input should be a valid number [type=float_type, input_value=datetime.timedelta(0), input_type=timedelta]
    For further information visit https://errors.pydantic.dev/2.10/v/float_type
```