### PR TITLE
Update ci - release on tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,10 @@ name: Release
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+    tags:
+      - '*'
 
 env:
   UV_PYTHON: 3.12
@@ -39,9 +42,10 @@ jobs:
       - name: Build package
         run: uv build
 
-  # Build and release to PyPI
+  # Build and release to PyPI  
   release:
     # needs: [validate]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     environment:


### PR DESCRIPTION
We shouldn't automatically release on merge but on push tag action. This PR fixes that.