### PR TITLE
Fix - base url validation

### DIFF
--- a/src/patronus/init.py
+++ b/src/patronus/init.py
@@ -84,7 +84,10 @@ def init(
         )
         ```
     """
-    if api_url != config.DEFAULT_API_URL and otel_endpoint == config.DEFAULT_OTEL_ENDPOINT:
+    api_url = api_url and api_url.rstrip("/")
+    otel_endpoint = otel_endpoint and otel_endpoint.rstrip("/")
+
+    if api_url != config.DEFAULT_API_URL and (otel_endpoint is None or otel_endpoint == config.DEFAULT_OTEL_ENDPOINT):
         raise ValueError(
             "'api_url' is set to non-default value, "
             "but 'otel_endpoint' is a default. Change 'otel_endpoint' to point to the same environment as 'api_url'"


### PR DESCRIPTION
Setting default api url with trailing slash and default otel endpoint causes validation error:
```
patronus.init(
    ....
    api_url="https://api.patronus.ai/"
    otel_endpoint="https://otel.patronus.ai:4317"
)
```

